### PR TITLE
feat: make heading cleanup pattern configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ obsidian_to_Anki 无疑是个非常好用的插件，且提供了非常丰富的
 通过本插件的定制化后，你可以得到
 1. 生成带有「父牌组::子牌组」这样的卡组名
 2. 在四级标题下生成「标题级的回链」，这样在anki中复习时可以直接跳转到该问题标题，以进行修改
-3. 对卡片里的标题、内容做了些字符上的清理，可以更好地配合obsidian_to_Anki插件生成更美观的卡片
+3. 对卡片里的标题、内容做了字符上的清理（默认移除反引号、尖括号与方括号，可自定义），可以更好地配合obsidian_to_Anki插件生成更美观的卡片
 4. 可选择插件的作用范围：全部文件、仅在指定文件夹，或排除某些路径
 
 **obsidian\_to\_Anki** is already a terrific plugin with a rich set of card-creation modes.
@@ -18,7 +18,7 @@ After running it, you get:
 
 1. **Deck names in the form `ParentDeck::SubDeck`** automatically generated.
 2. A **“heading-level backlink”** inserted right under every H4 question, letting you jump straight to that section in Obsidian while reviewing in Anki.
-3. Small character-level clean-ups on both headings and content, yielding tidier cards when processed by obsidian\_to\_Anki.
+3. Small character-level clean-ups on both headings and content (defaults strip backticks, angle brackets, and square brackets, and is customizable), yielding tidier cards when processed by obsidian\_to\_Anki.
 4. Configurable run scope: run on all files, only within chosen folders, or skip selected paths.
 
 ## 作用范围示例 / Scope demo

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ obsidian_to_Anki 无疑是个非常好用的插件，且提供了非常丰富的
 通过本插件的定制化后，你可以得到
 1. 生成带有「父牌组::子牌组」这样的卡组名
 2. 在四级标题下生成「标题级的回链」，这样在anki中复习时可以直接跳转到该问题标题，以进行修改
-3. 对卡片里的标题、内容做了字符上的清理（默认移除反引号、尖括号与方括号，可自定义），可以更好地配合obsidian_to_Anki插件生成更美观的卡片
+3. 对卡片里的标题、内容做了字符上的清理（默认移除反引号、尖括号与方括号，可在设置中以空格分隔输入要去除的字符），可以更好地配合obsidian_to_Anki插件生成更美观的卡片
 4. 可选择插件的作用范围：全部文件、仅在指定文件夹，或排除某些路径
 
 **obsidian\_to\_Anki** is already a terrific plugin with a rich set of card-creation modes.
@@ -18,7 +18,7 @@ After running it, you get:
 
 1. **Deck names in the form `ParentDeck::SubDeck`** automatically generated.
 2. A **“heading-level backlink”** inserted right under every H4 question, letting you jump straight to that section in Obsidian while reviewing in Anki.
-3. Small character-level clean-ups on both headings and content (defaults strip backticks, angle brackets, and square brackets, and is customizable), yielding tidier cards when processed by obsidian\_to\_Anki.
+3. Small character-level clean-ups on both headings and content (defaults strip backticks, angle brackets, and square brackets; you can add more characters in settings, separated by spaces), yielding tidier cards when processed by obsidian\_to\_Anki.
 4. Configurable run scope: run on all files, only within chosen folders, or skip selected paths.
 
 ## 作用范围示例 / Scope demo

--- a/main.ts
+++ b/main.ts
@@ -1,7 +1,7 @@
 // Obsidian Plugin – Anki Helper
 // Implements:
 // 1. Under every H4 heading (####) insert a backlink to the heading
-// 2. Remove specific characters (` < >) inside H4 heading text itself
+// 2. Remove configurable characters inside H4 heading text itself
 // 3. Check and insert TARGET DECK section below YAML or before first heading
 // 4. Delete empty trailing list items (ordered & unordered)
 // 5. Ensure one blank line containing a single space between a list and the following paragraph
@@ -29,6 +29,7 @@ function globToRegExp(pattern: string): RegExp {
 /** Settings */
 interface AnkiHelperSettings {
   headingLevel: number; // default 4 (####)
+  headingRemovePattern: string;       // regex pattern for characters to remove in headings
   targetDeckTemplate: string; // e.g. '[[anki背诵]]::[[filename]]'
   enableTargetDeck: boolean;            // 启用 TARGET DECK 自动插入，增加开关
   enableHeadingOps: boolean;            // 启用 标题清理 + 标题级回链，增加开关
@@ -40,6 +41,7 @@ interface AnkiHelperSettings {
 
 const DEFAULT_SETTINGS: AnkiHelperSettings = {
   headingLevel: 4,
+  headingRemovePattern: "[`<>\\[\\]]+",
   targetDeckTemplate: "[[anki背诵]]::[[filename]]",
   enableTargetDeck: true,
   enableHeadingOps: true,
@@ -128,14 +130,21 @@ export default class AnkiHelperPlugin extends Plugin {
     let changed = false;
     const hPrefix = "#".repeat(this.settings.headingLevel) + " ";
     const noteName = file.basename;
-	const start = findYamlEnd(lines);           // ← 从 YAML 之后开始
+    const start = findYamlEnd(lines);           // ← 从 YAML 之后开始
+
+    let removeRegex: RegExp;
+    try {
+      removeRegex = new RegExp(this.settings.headingRemovePattern, "g");
+    } catch {
+      removeRegex = /[`<>\[\]]+/g;
+    }
 
     for (let i = start; i < lines.length; i++) {
       const line = lines[i];
       if (!line.startsWith(hPrefix)) continue;
 
       const rawHeading = line.slice(hPrefix.length);
-      const cleanHeading = rawHeading.replace(/[`<>]+/g, "").trim();
+      const cleanHeading = rawHeading.replace(removeRegex, "").trim();
       if (rawHeading !== cleanHeading) {
         lines[i] = hPrefix + cleanHeading;
         changed = true;
@@ -319,7 +328,7 @@ class AnkiHelperSettingTab extends PluginSettingTab {
   cardCleanup.createEl("div", { cls: "ah-card-title", text: "三，清理与排版" });
   cardCleanup.createEl("div", {
     cls: "ah-card-desc",
-    text: "清理「问题标题」中的特殊字符并插入回链；删除空列表项；列表与段落间自动插空行。"
+    text: "清理「问题标题」中的特殊字符（可自定义）并插入回链；删除空列表项；列表与段落间自动插空行。"
   });
 
   new Setting(cardCleanup)
@@ -331,6 +340,19 @@ class AnkiHelperSettingTab extends PluginSettingTab {
         this.plugin.settings.enableHeadingOps = v;
         await this.plugin.saveSettings();
       })
+    );
+
+  new Setting(cardCleanup)
+    .setName("标题中要删除的字符")
+    .setDesc("输入要从标题中移除的字符，支持正则表达式。默认移除反引号、尖括号与方括号。")
+    .addText(text =>
+      text
+        .setPlaceholder("[`<>\\[\\]]+")
+        .setValue(this.plugin.settings.headingRemovePattern)
+        .onChange(async (value) => {
+          this.plugin.settings.headingRemovePattern = value.trim() || "[`<>\\[\\]]+";
+          await this.plugin.saveSettings();
+        })
     );
 
   new Setting(cardCleanup)

--- a/main.ts
+++ b/main.ts
@@ -331,6 +331,7 @@ class AnkiHelperSettingTab extends PluginSettingTab {
     text: "清理「问题标题」中的特殊字符（可自定义）并插入回链；删除空列表项；列表与段落间自动插空行。"
   });
 
+  let charSetting: Setting;
   new Setting(cardCleanup)
     .setName("启用：标题清理 + 标题级回链 功能")
     .setDesc("注：清理标题特殊字符后，将不影响[[ ]]的生成。同时插入类似 [[Note#Heading]] 的回链，以方便在anki复习时直接跳到对应的卡片中。")
@@ -338,11 +339,12 @@ class AnkiHelperSettingTab extends PluginSettingTab {
       .setValue(this.plugin.settings.enableHeadingOps)
       .onChange(async (v) => {
         this.plugin.settings.enableHeadingOps = v;
+        charSetting.setDisabled(!v);
         await this.plugin.saveSettings();
       })
     );
 
-  new Setting(cardCleanup)
+  charSetting = new Setting(cardCleanup)
     .setName("标题中要删除的字符")
     .setDesc("输入要从标题中移除的字符，支持正则表达式。默认移除反引号、尖括号与方括号。")
     .addText(text =>
@@ -354,6 +356,7 @@ class AnkiHelperSettingTab extends PluginSettingTab {
           await this.plugin.saveSettings();
         })
     );
+  charSetting.setDisabled(!this.plugin.settings.enableHeadingOps);
 
   new Setting(cardCleanup)
     .setName("启用：列表与段落间自动留空行功能")

--- a/main.ts
+++ b/main.ts
@@ -26,10 +26,14 @@ function globToRegExp(pattern: string): RegExp {
   return new RegExp("^" + single.replace(/§§/g, ".*") + "$");
 }
 
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 /** Settings */
 interface AnkiHelperSettings {
   headingLevel: number; // default 4 (####)
-  headingRemovePattern: string;       // regex pattern for characters to remove in headings
+  headingRemoveChars: string;       // space-separated chars to remove from headings
   targetDeckTemplate: string; // e.g. '[[anki背诵]]::[[filename]]'
   enableTargetDeck: boolean;            // 启用 TARGET DECK 自动插入，增加开关
   enableHeadingOps: boolean;            // 启用 标题清理 + 标题级回链，增加开关
@@ -41,7 +45,7 @@ interface AnkiHelperSettings {
 
 const DEFAULT_SETTINGS: AnkiHelperSettings = {
   headingLevel: 4,
-  headingRemovePattern: "[`<>\\[\\]]+",
+  headingRemoveChars: "` < > [ ]",
   targetDeckTemplate: "[[anki背诵]]::[[filename]]",
   enableTargetDeck: true,
   enableHeadingOps: true,
@@ -132,12 +136,10 @@ export default class AnkiHelperPlugin extends Plugin {
     const noteName = file.basename;
     const start = findYamlEnd(lines);           // ← 从 YAML 之后开始
 
-    let removeRegex: RegExp;
-    try {
-      removeRegex = new RegExp(this.settings.headingRemovePattern, "g");
-    } catch {
-      removeRegex = /[`<>\[\]]+/g;
-    }
+    const rawChars = this.settings.headingRemoveChars.trim() || "` < > [ ]";
+    const tokens = rawChars.split(/\s+/).filter(Boolean);
+    const pattern = tokens.length ? tokens.map(escapeRegExp).join("|") : "`|<|>|\\[|\\]";
+    const removeRegex = new RegExp(pattern, "g");
 
     for (let i = start; i < lines.length; i++) {
       const line = lines[i];
@@ -346,13 +348,13 @@ class AnkiHelperSettingTab extends PluginSettingTab {
 
   charSetting = new Setting(cardCleanup)
     .setName("标题中要删除的字符")
-    .setDesc("输入要从标题中移除的字符，支持正则表达式。默认移除反引号、尖括号与方括号。")
+    .setDesc("输入要从标题中移除的字符，以空格分隔。默认移除：` < > [ ]")
     .addText(text =>
       text
-        .setPlaceholder("[`<>\\[\\]]+")
-        .setValue(this.plugin.settings.headingRemovePattern)
+        .setPlaceholder("` < > [ ]")
+        .setValue(this.plugin.settings.headingRemoveChars)
         .onChange(async (value) => {
-          this.plugin.settings.headingRemovePattern = value.trim() || "[`<>\\[\\]]+";
+          this.plugin.settings.headingRemoveChars = value.trim() || "` < > [ ]";
           await this.plugin.saveSettings();
         })
     );


### PR DESCRIPTION
## Summary
- allow specifying characters to strip from headings via `headingRemovePattern` setting
- expose heading cleanup pattern in settings tab for user input
- default removal characters now include backticks and angle/square brackets
- document customizable heading cleanup in README

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3f8882df8832ca43d0c710e3d43df